### PR TITLE
Service to get ordered list of address hierarchy levels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 .settings
+*.iml
+.DS_Store
 target/

--- a/omod/src/main/java/org/openmrs/module/addresshierarchy/web/controller/ajax/AddressHierarchyAjaxController.java
+++ b/omod/src/main/java/org/openmrs/module/addresshierarchy/web/controller/ajax/AddressHierarchyAjaxController.java
@@ -229,6 +229,25 @@ public class AddressHierarchyAjaxController {
 			generateFullAddressResponse(response, addresses, separator);
 		}
 	}
+
+    /**
+     * Returns ordered array of hierarchy levels.
+     */
+    @RequestMapping("/module/addresshierarchy/ajax/getOrderedAddressHierarchyLevels.form")
+    @ResponseBody
+    public ArrayList<ModelMap> getOrderedAddressHierarchyLevels() throws Exception {
+        AddressHierarchyService ahService = Context.getService(AddressHierarchyService.class);
+        List<AddressHierarchyLevel> hierarchyLevels = ahService.getOrderedAddressHierarchyLevels();
+        ArrayList<ModelMap> map = new ArrayList<ModelMap>();
+        for (AddressHierarchyLevel hierarchyLevel : hierarchyLevels) {
+            ModelMap modelMap = new ModelMap();
+            modelMap.addAttribute("name", hierarchyLevel.getName());
+            String fieldName = (hierarchyLevel.getAddressField() != null) ? hierarchyLevel.getAddressField().getName() : null;
+            modelMap.addAttribute("addressField", fieldName);
+            map.add(modelMap);
+        }
+        return map;
+    }
 	
 	/**
 	 * Utility methods


### PR DESCRIPTION
In bahmni we have a client side app which would need this API to dynamically configure the address fields for different implementations. The API contract is as below

```
[
    {
        "name": "Country",
        "addressField": "country"
    },
    {
        "name": "State",
        "addressField": "stateProvince"
    },
    {
        "name": "District",
        "addressField": "countyDistrict"
    },
    {
        "name": "Tehsil",
        "addressField": "address3"
    },
    {
        "name": "Village",
        "addressField": "cityVillage"
    }
]
```
