### PR TITLE
Sending 'required' field in getOrderedAddressHierarchyLevels service response

### DIFF
--- a/omod/src/main/java/org/openmrs/module/addresshierarchy/web/controller/ajax/AddressHierarchyAjaxController.java
+++ b/omod/src/main/java/org/openmrs/module/addresshierarchy/web/controller/ajax/AddressHierarchyAjaxController.java
@@ -244,6 +244,7 @@ public class AddressHierarchyAjaxController {
             modelMap.addAttribute("name", hierarchyLevel.getName());
             String fieldName = (hierarchyLevel.getAddressField() != null) ? hierarchyLevel.getAddressField().getName() : null;
             modelMap.addAttribute("addressField", fieldName);
+            modelMap.addAttribute("required", hierarchyLevel.getRequired());
             map.add(modelMap);
         }
         return map;


### PR DESCRIPTION
The contact will be:

```
[
    {
        "name": "Country",
        "addressField": "country",
        "required": true
    },
    {
        "name": "State",
        "addressField": "stateProvince",
        "required": false
    }
]
```
