### PR TITLE
Show the address hierarachy levels in the right order

### DIFF
--- a/omod/src/main/java/org/openmrs/module/addresshierarchy/web/controller/ManageAddressHierarchyController.java
+++ b/omod/src/main/java/org/openmrs/module/addresshierarchy/web/controller/ManageAddressHierarchyController.java
@@ -67,7 +67,7 @@ public class ManageAddressHierarchyController {
 	public List<AddressHierarchyLevel> getOrderedAddressHierarchyLevels() {
 		// before getting the levels, we first make sure the parents are set properly (mainly to handle any migration from the 1.2 model)
 		Context.getService(AddressHierarchyService.class).setAddressHierarchyLevelParents();
-		return Context.getService(AddressHierarchyService.class).getAddressHierarchyLevels();
+		return Context.getService(AddressHierarchyService.class).getOrderedAddressHierarchyLevels();
 	}
 	
 	@ModelAttribute("messages")


### PR DESCRIPTION
The manage address hierarchy page was not ordering the hierarchy level by the level. The hierarchy set up by upload shows up fine. But if you insert an intermediate level using sql script, it used to show up at the bottom of the list.
