### PR TITLE
ADDR-67| Allow longitude, latitude to be listed in address field mappings

### DIFF
--- a/api/src/main/java/org/openmrs/module/addresshierarchy/AddressField.java
+++ b/api/src/main/java/org/openmrs/module/addresshierarchy/AddressField.java
@@ -18,7 +18,8 @@ public enum AddressField {
 	ADDRESS_1("address1"), ADDRESS_2("address2"), ADDRESS_3("address3"), NEIGHBORHOOD_CELL("neighborhoodCell"), 
 	ADDRESS_4("address4"), TOWNSHIP_DIVISION("townshipDivision"), ADDRESS_5("address5"), SUBREGION("subregion"), 
 	ADDRESS_6("address6"), REGION("region"), CITY_VILLAGE("cityVillage"), COUNTY_DISTRICT("countyDistrict"), 
-	STATE_PROVINCE("stateProvince"), COUNTRY("country"), POSTAL_CODE("postalCode");
+	STATE_PROVINCE("stateProvince"), COUNTRY("country"), POSTAL_CODE("postalCode"), LONGITUDE("longitude"),
+    LATITUDE("latitude");
 	
 	String name;
 	


### PR DESCRIPTION
The longitude and latitude were not listed in editAddressHierarchyLevel page after adding them to nameMappings in org.openmrs.layout.web.address.AddressTemplate. 
