### PR TITLE
ADDR-71 | changed end point to search address based on the parent entry.

### DIFF
--- a/api/src/main/java/org/openmrs/module/addresshierarchy/db/AddressHierarchyDAO.java
+++ b/api/src/main/java/org/openmrs/module/addresshierarchy/db/AddressHierarchyDAO.java
@@ -51,7 +51,9 @@ public interface AddressHierarchyDAO {
 	 * Gets all address hierarchy entries associated with the a certain level that have the specified name and the specified parent
 	 */
 	public List<AddressHierarchyEntry> getAddressHierarchyEntriesByLevelAndNameAndParent(AddressHierarchyLevel level, String name, AddressHierarchyEntry parent);
-	
+
+	public List<AddressHierarchyEntry> getAddressHierarchyEntriesByLevelAndLikeNameAndParent(AddressHierarchyLevel level, String name, AddressHierarchyEntry parent);
+
 	/**
 	 * Gets all the address hierarchy entries that are children of the specified entry
 	 */

--- a/api/src/main/java/org/openmrs/module/addresshierarchy/db/hibernate/HibernateAddressHierarchyDAO.java
+++ b/api/src/main/java/org/openmrs/module/addresshierarchy/db/hibernate/HibernateAddressHierarchyDAO.java
@@ -118,6 +118,16 @@ public class HibernateAddressHierarchyDAO implements AddressHierarchyDAO {
 		return criteria.list();
 	}
 	
+    @SuppressWarnings("unchecked")
+	public List<AddressHierarchyEntry> getAddressHierarchyEntriesByLevelAndLikeNameAndParent(AddressHierarchyLevel addressHierarchyLevel, String name, AddressHierarchyEntry parent) {
+		Session session = sessionFactory.getCurrentSession();
+		Criteria criteria = session.createCriteria(AddressHierarchyEntry.class);
+		criteria.createCriteria("level").add(Restrictions.eq("levelId", addressHierarchyLevel.getId()));
+		criteria.createCriteria("parent").add(Restrictions.eq("addressHierarchyEntryId", parent.getId()));
+		criteria.add(Restrictions.ilike("name", name, MatchMode.START));
+		return criteria.list();
+	}
+
 	@SuppressWarnings("unchecked")
 	public List<AddressHierarchyEntry> getChildAddressHierarchyEntries(AddressHierarchyEntry entry) {
 		Session session = sessionFactory.getCurrentSession();

--- a/api/src/main/java/org/openmrs/module/addresshierarchy/service/AddressHierarchyService.java
+++ b/api/src/main/java/org/openmrs/module/addresshierarchy/service/AddressHierarchyService.java
@@ -181,7 +181,9 @@ public interface AddressHierarchyService{
 	 * @should return null if level, name, or parent is blank or empty
 	 */
 	public List<AddressHierarchyEntry> getAddressHierarchyEntriesByLevelAndNameAndParent(AddressHierarchyLevel level, String name, AddressHierarchyEntry parent);
-	
+
+	public List<AddressHierarchyEntry> getAddressHierarchyEntriesByLevelAndLikeNameAndParent(AddressHierarchyLevel level, String name, AddressHierarchyEntry parent);
+
 	/**
 	 * Returns all address hierarchy entries at the top level in the hierarchy
 	 * 

--- a/api/src/main/java/org/openmrs/module/addresshierarchy/service/AddressHierarchyServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/addresshierarchy/service/AddressHierarchyServiceImpl.java
@@ -448,7 +448,16 @@ public class AddressHierarchyServiceImpl implements AddressHierarchyService {
 	    return dao.getAddressHierarchyEntriesByLevelAndNameAndParent(level, name, parent);
     }
 	
-	
+	@Transactional(readOnly = true)
+	public List<AddressHierarchyEntry> getAddressHierarchyEntriesByLevelAndLikeNameAndParent(AddressHierarchyLevel level, String name, AddressHierarchyEntry parent) {
+		if (level == null || parent == null) {
+			return null;
+		}
+
+	    return dao.getAddressHierarchyEntriesByLevelAndLikeNameAndParent(level, name, parent);
+    }
+
+
 	@Transactional(readOnly = true)
 	public List<AddressHierarchyEntry> getAddressHierarchyEntriesAtTopLevel() {
 		return getAddressHierarchyEntriesByLevel(getTopAddressHierarchyLevel());


### PR DESCRIPTION
I have created a [ticket](https://issues.openmrs.org/browse/ADDR-71) regarding address hierarchy search functionality based on the parent field.

Review the code and merge to the next release of address hierarchy. And also, can you release it as soon as possible.