### PR TITLE
ADDR-72: HTML Code displayed on Advanced Features Admin Page

### DIFF
--- a/omod/src/main/webapp/admin/advancedFeatures.jsp
+++ b/omod/src/main/webapp/admin/advancedFeatures.jsp
@@ -31,11 +31,11 @@
 <table cellspacing="0" cellpadding="0" class="box">
 
 <tr>
-	<td class="tableCell"><spring:message code="addresshierarchy.admin.configureAddressToEntryMappings.instructions" /></td>
+	<td class="tableCell"><spring:message code="addresshierarchy.admin.configureAddressToEntryMappings.instructions" htmlEscape="false" /></td>
 </tr>
 
 <tr>
-	<td class="tableCell"><nobr><input type="checkbox" name="updaterStarted" <c:if test="${updaterStarted}">checked</c:if>/> <spring:message code="addresshierarchy.admin.scheduleAddressToEntryMappings" arguments='<input type="text" name="repeatInterval" value="${repeatInterval}" size="6"/>'/></nobr></td>
+	<td class="tableCell"><nobr><input type="checkbox" name="updaterStarted" <c:if test="${updaterStarted}">checked</c:if>/> <spring:message code="addresshierarchy.admin.scheduleAddressToEntryMappings" arguments='<input type="number" name="repeatInterval" value="${repeatInterval}" size="6"/>' htmlEscape="false"/></nobr></td>
 </tr>
 
 <tr>


### PR DESCRIPTION
https://issues.openmrs.org/browse/ADDR-72

The advanced features page showed HTML retrieved from Spring as raw
text. The page now shows the HTML properly, and the input only accepts numbers.

![address hierarchy old](https://user-images.githubusercontent.com/46609084/55987511-50e3bd00-5c67-11e9-905f-569b6c0ab58c.png)

![image](https://user-images.githubusercontent.com/46609084/55987119-6c01fd00-5c66-11e9-8dfe-bdafaa1d91f4.png)