### PR TITLE
ADDR-116: Unable to import configuration files when application directory does not end with a slash

### DIFF
--- a/api/src/main/java/org/openmrs/module/addresshierarchy/config/AddressConfigurationLoader.java
+++ b/api/src/main/java/org/openmrs/module/addresshierarchy/config/AddressConfigurationLoader.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Paths;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
@@ -40,17 +41,13 @@ public class AddressConfigurationLoader {
 	 * @return The path to the configuration subdirectory.
 	 */
 	public static String getConfigPath() {
-		return new StringBuilder()
-				.append(OpenmrsUtil.getApplicationDataDirectory())
-				.append("configuration")
-				.toString();
+		return Paths.get(OpenmrsUtil.getApplicationDataDirectory(),
+			"configuration").toString();
 	}
 	
 	public static String getChecksumsPath() {
-		return new StringBuilder()
-				.append(OpenmrsUtil.getApplicationDataDirectory())
-				.append("configuration_checksums")
-				.toString();
+		return Paths.get(OpenmrsUtil.getApplicationDataDirectory(),
+				"configuration_checksums").toString();
 	}
 
 	public static void loadAddressConfiguration() {
@@ -59,9 +56,14 @@ public class AddressConfigurationLoader {
 
 		String xmlConfigFileName = ADDR_CONFIG_FILE_NAME;
 
+		File domainDir = new File(configUtil.domainDirPath);
+		if (!domainDir.exists()) {
+			log.info("Address hierarchy domain folder appears not present, skipping the loading process: " + domainDir.getPath());
+			return;
+		}
 		File configFile = configUtil.getConfigFile(xmlConfigFileName);
 		if (!configFile.exists()) {
-			log.warn("Address hierarchy configuration file appears invalid, skipping the loading process: " + xmlConfigFileName);
+			log.error("Address hierarchy configuration file appears invalid, skipping the loading process: " + configFile.getPath());
 			return;
 		}
 

--- a/api/src/main/java/org/openmrs/module/addresshierarchy/config/ConfigDirUtil.java
+++ b/api/src/main/java/org/openmrs/module/addresshierarchy/config/ConfigDirUtil.java
@@ -5,6 +5,7 @@ import java.io.FileInputStream;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -20,27 +21,27 @@ import org.apache.commons.logging.LogFactory;
  * Helps read and write to and from the configuration and checksum directories.
  */
 public class ConfigDirUtil {
-	
+
 	protected static final String NOT_COMPUTABLE_CHECKSUM = "not_computable_checksum";
-	
+
 	protected static final String NOT_READABLE_CHECKSUM = "not_readadble_checksum";
-	
+
 	protected static final String CHECKSUM_FILE_EXT = "checksum";
-	
+
 	protected static Log log = LogFactory.getLog(ConfigDirUtil.class);
-	
+
 	/*
 	 * The absolute path to the configuration domain subdirectory.
 	 * Eg. "../configuration/addresshierarchy"
 	 */
 	protected String domainDirPath = "";
-	
+
 	/*
 	 * The absolute path to the configuration domain checksum subdirectory.
 	 * Eg. "../configuration_checksums/addresshierarchy"
 	 */
 	protected String checksumDirPath = "";
-	
+
 	/**
 	 * @param configDirPath The absolute path to the config directory, eg. "../configuration"
 	 * @param checksumDirPath The absolute path to the checksum directory, eg.
@@ -48,30 +49,30 @@ public class ConfigDirUtil {
 	 * @param domain The metadata domain, eg. "addresshierarchy"
 	 */
 	public ConfigDirUtil(String configDirPath, String checksumDirPath, String domain) {
-		this.domainDirPath = new StringBuilder(configDirPath).append(File.separator).append(domain).toString();
-		this.checksumDirPath = new StringBuilder(checksumDirPath).append(File.separator).append(domain).toString();
+		this.domainDirPath = Paths.get(configDirPath, domain).toString();
+		this.checksumDirPath = Paths.get(checksumDirPath, domain).toString();
 	}
-	
+
 	public String getDomainDirPath() {
 		return domainDirPath;
 	}
-	
+
 	public String getChecksumDirPath() {
 		return checksumDirPath;
 	}
-	
+
 	@Override
 	public String toString() {
 		return domainDirPath;
 	}
-	
+
 	/*
 	 * To filter files of a certain extension only.
 	 * @param extension The file extension to filter for.
 	 */
 	protected static FilenameFilter getExtensionFilenameFilter(final String extension) {
 		return new FilenameFilter() {
-			
+
 			@Override
 			public boolean accept(File dir, String name) {
 				String ext = FilenameUtils.getExtension(name);
@@ -88,13 +89,13 @@ public class ConfigDirUtil {
 			}
 		};
 	}
-	
+
 	/*
 	 * To filter directories only.
 	 */
 	protected static FilenameFilter getDirectoryFilenameFilter() {
 		return new FilenameFilter() {
-			
+
 			@Override
 			public boolean accept(File dir, String name) {
 				if (new File(dir, name).isDirectory()) {
@@ -104,10 +105,10 @@ public class ConfigDirUtil {
 			}
 		};
 	}
-	
+
 	/**
 	 * Extracts the name of a file based on the to the domain directory path.
-	 * 
+	 *
 	 * @param domainDirPath The absolute path to the domain directory, eg.
 	 *            "../configuration/addresshierarchy"
 	 * @param filePath The absolute path to a file inside the config. directory structure, eg.
@@ -117,18 +118,18 @@ public class ConfigDirUtil {
 	protected static String getFileName(String domainDirPath, String filePath) {
 		return filePath.replace(new StringBuilder().append(domainDirPath).append(File.separator).toString(), "");
 	}
-	
+
 	/**
 	 * @see #getFileName(String, String)
 	 */
 	public String getFileName(String filePath) {
 		return getFileName(domainDirPath, filePath);
 	}
-	
+
 	/**
 	 * Returns the checksum of a config file if the file has been updated since the last checksum
 	 * was saved.
-	 * 
+	 *
 	 * @param domainDirPath The absolute path to the domain directory, eg.
 	 *            "../configuration/addresshierarchy"
 	 * @param checksumDirPath The absolute path to the checksum directory, eg.
@@ -141,44 +142,44 @@ public class ConfigDirUtil {
 		String checksum = computeChecksum(domainDirPath, configFileName);
 		return savedChecksum.equals(checksum) ? "" : checksum;
 	}
-	
+
 	/**
 	 * @see #getChecksumIfChanged(String, String)
 	 */
 	public String getChecksumIfChanged(String configFileName) {
 		return getChecksumIfChanged(domainDirPath, checksumDirPath, configFileName);
 	}
-	
+
 	/**
 	 * Fetches all the files in a directory based on their extension.
-	 * 
+	 *
 	 * @param domainDirPath The absolute path to the domain directory, eg.
 	 *            "../configuration/addresshierarchy"
 	 * @param extension The extension to filter for, eg "xml".
 	 * @return The list of {@link File} instances.
 	 */
 	protected static List<File> getFiles(String domainDirPath, String extension) {
-		
+
 		final List<File> allFiles = new ArrayList<File>();
-		
+
 		final File[] files = new File(domainDirPath).listFiles(getExtensionFilenameFilter(extension));
 		if (files != null) {
 			allFiles.addAll(Arrays.asList(files));
 		}
-		
+
 		return allFiles;
 	}
-	
+
 	/**
 	 * @see #getFiles(String, String)
 	 */
 	public List<File> getFiles(String extension) {
 		return getFiles(domainDirPath, extension);
 	}
-	
+
 	/**
 	 * Fetches the config. file from its relative path inside the configuration folder.
-	 * 
+	 *
 	 * @param dirPath The absolute path to the containing directory, eg.
 	 *            "../configuration/addresshierarchy" or
 	 *            "../configuration_checksums/addresshierarchy"
@@ -190,25 +191,25 @@ public class ConfigDirUtil {
 		path.append(File.separator).append(fileName);
 		return new File(path.toString());
 	}
-	
+
 	/**
 	 * @see #getFile(String, String)
 	 */
 	public File getConfigFile(String fileName) {
 		return getFile(domainDirPath, fileName);
 	}
-	
+
 	/**
 	 * Returns the checksum file name inside the domain folder.
-	 * 
+	 *
 	 * @param configFileName The config file name, eg. "config.xml"
 	 * @return The checksum file name, eg. "config.checksum"
 	 */
 	public static String toChecksumFileName(String configFileName) {
-		// addressConfiguration.xml -> addressConfiguration.checksum 
+		// addressConfiguration.xml -> addressConfiguration.checksum
 		return FilenameUtils.getBaseName(configFileName) + "." + CHECKSUM_FILE_EXT;
 	}
-	
+
 	/**
 	 * @param checksumDirPath The absolute path to the checksum directory, eg.
 	 *            "../configuration_checksums"
@@ -216,13 +217,13 @@ public class ConfigDirUtil {
 	 * @return The checksum of the config file that was last successfully loaded.
 	 */
 	protected static String readLatestChecksum(String checksumDirPath, String configFileName) {
-		
+
 		String checksum = NOT_READABLE_CHECKSUM;
-		
+
 		if (!new File(checksumDirPath).exists()) {
 			return checksum;
 		}
-		
+
 		final String checksumFileName = toChecksumFileName(configFileName);
 		try {
 			final File checksumFile = getFile(checksumDirPath, checksumFileName);
@@ -235,26 +236,26 @@ public class ConfigDirUtil {
 		}
 		return checksum;
 	}
-	
+
 	/**
 	 * @see #readLatestChecksum(String, String)
 	 */
 	public String readLatestChecksum(String configFileName) {
 		return readLatestChecksum(checksumDirPath, configFileName);
 	}
-	
+
 	/**
 	 * Compute the checksum of a configuration file.
-	 * 
+	 *
 	 * @param domainDirPath The absolute path to the domain directory, eg.
 	 *            "../configuration/addresshierarchy"
 	 * @param configFileName The config file name, eg. "config.xml"
 	 * @return The checksum of the file.
 	 */
 	protected static String computeChecksum(String domainDirPath, String configFileName) {
-		
+
 		String checksum = NOT_COMPUTABLE_CHECKSUM;
-		
+
 		File configFile = getFile(domainDirPath, configFileName);
 		if (configFile.exists()) {
 			try {
@@ -269,30 +270,30 @@ public class ConfigDirUtil {
 		}
 		return checksum;
 	}
-	
+
 	/**
 	 * @see #computeChecksum(String, String)
 	 */
 	public String computeChecksum(String configFileName) {
 		return computeChecksum(domainDirPath, configFileName);
 	}
-	
+
 	/**
 	 * Writes the the checksum of a config file into the corresponding .checksum file.
-	 * 
+	 *
 	 * @param checksumDirPath The absolute path to the checksum directory, eg.
 	 *            "../configuration_checksums"
 	 * @param configFileName The config file name, eg. "config.xml"
 	 * @param checksum The checksum hash of the config file.
 	 */
 	protected static void writeChecksum(String checksumDirPath, String checksumFileName, String checksum) {
-		
+
 		deleteChecksum(checksumDirPath, checksumFileName);
-		
+
 		if (NOT_COMPUTABLE_CHECKSUM.equals(checksum)) {
 			return;
 		}
-		
+
 		try {
 			FileUtils.writeStringToFile(getFile(checksumDirPath, checksumFileName), checksum, "UTF-8");
 		}
@@ -300,23 +301,23 @@ public class ConfigDirUtil {
 			log.error("Error writing hash ('" + checksum + "') of configuration file to: " + checksumFileName, e);
 		}
 	}
-	
+
 	/**
 	 * @see #writeChecksum(String, String, String)
 	 */
 	public void writeChecksum(String configFileName, String checksum) {
 		writeChecksum(checksumDirPath, ConfigDirUtil.toChecksumFileName(configFileName), checksum);
 	}
-	
+
 	/**
 	 * Deletes the checksum file of a config. file.
-	 * 
+	 *
 	 * @param checksumDirPath The absolute path to the checksum directory, eg.
 	 *            "../configuration_checksums"
 	 * @param configFileName The config file name, eg. "config.xml"
 	 */
 	protected static void deleteChecksum(String checksumDirPath, String checksumFileName) {
-		
+
 		try {
 			Files.deleteIfExists(getFile(checksumDirPath, checksumFileName).toPath());
 		}
@@ -324,25 +325,25 @@ public class ConfigDirUtil {
 			log.warn("Error deleting hash of configuration file: " + checksumFileName, e);
 		}
 	}
-	
+
 	/**
 	 * @see #deleteChecksum(String, String)
 	 */
 	public void deleteChecksum(String checksumFileName) {
 		deleteChecksum(checksumDirPath, checksumFileName);
 	}
-	
+
 	/**
 	 * Removes all the checksum files inside the provided directory.
-	 * 
+	 *
 	 * @param checksumDirPath The absolute path to a config directory, eg.
 	 *            "../configuration/addresshierarchy" or "../configuration"
 	 * @param recursive Set to true to continue recursively into subdirectories.
 	 */
 	public static void deleteChecksums(String checksumDirPath, boolean recursive) {
-		
+
 		deleteChecksums(checksumDirPath);
-		
+
 		if (recursive) {
 			final String[] dirNames = new File(checksumDirPath).list(getDirectoryFilenameFilter());
 			if (dirNames != null) {
@@ -353,31 +354,31 @@ public class ConfigDirUtil {
 			}
 		}
 	}
-	
+
 	/**
 	 * @see #deleteChecksums(String, boolean)
 	 */
 	public void deleteChecksums(boolean recursive) {
 		deleteChecksums(checksumDirPath, recursive);
 	}
-	
+
 	/**
 	 * @see #deleteChecksums(boolean)
 	 */
 	public void deleteChecksums() {
 		deleteChecksums(checksumDirPath);
 	}
-	
+
 	/**
 	 * Removes all the checksum files inside the provided directory.
-	 * 
+	 *
 	 * @param checksumDirPath The absolute path to a config directory, eg.
 	 *            "../configuration/addresshierarchy" or "../configuration"
 	 */
 	public static void deleteChecksums(String checksumDirPath) {
-		
+
 		final File[] checksumFiles = new File(checksumDirPath).listFiles(getExtensionFilenameFilter(CHECKSUM_FILE_EXT));
-		
+
 		if (checksumFiles != null) {
 			for (File file : checksumFiles) {
 				file.delete();


### PR DESCRIPTION
- Replace use of `StringBuilder` by `Paths` to avoid no/double slashes.
- Load first the **configuration/** directory and if exists, then attempt to load the configuration files.
- Log an error when configuration file is not found, instead of a warning.