### PR TITLE
ADDR-125: AddressHierarchyConstants.PATTERN_NON_WORD_AND_NON_WHITESPACE to be more specific and should not match non-alphanumeric words

### DIFF
--- a/api/src/main/java/org/openmrs/module/addresshierarchy/AddressHierarchyConstants.java
+++ b/api/src/main/java/org/openmrs/module/addresshierarchy/AddressHierarchyConstants.java
@@ -21,7 +21,7 @@ public class AddressHierarchyConstants {
 	public static final Long TASK_PARAMETER_ADDRESS_ENTRY_MAP_DEFAULT_REPEAT_INTERVAL = new Long(86400);   // default repeat interval is once every 24 hours (24 hours = 86400 seconds)
 	
 	/* Precompile some standard Patterns that we are using */
-	public static final Pattern PATTERN_NON_WORD_AND_NON_WHITESPACE = Pattern.compile("[\\W&&\\S]+");   // matches sets of 1 or more characters that are both non-word (\W) and non-whitespace (\S))
+	public static final Pattern PATTERN_NON_WORD_AND_NON_WHITESPACE = Pattern.compile("[\\/\\\\\"'`~@#$%^&*()+{}\\[\\]<>,.!?-]+");   // matches sets of 1 or more of the characters: /\"'`~@#$%^&*()+{}[]<>,.!?-
 	public static final Pattern PATTERN_ANY_DIGIT = Pattern.compile("[\\d]+");  // matches one or more digits (0-9)
 	
 	// TODO: add some other global property that are currently directly referenced within the code

--- a/api/src/test/java/org/openmrs/module/addresshierarchy/AddressHierarchyServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/addresshierarchy/AddressHierarchyServiceTest.java
@@ -249,8 +249,8 @@ public class AddressHierarchyServiceTest extends BaseModuleContextSensitiveTest 
 	public void getAddressHierarchyEntryCountByLevel_shouldGetCountOfAddressHierarchyEntries() throws Exception {
 		AddressHierarchyService ahService = Context.getService(AddressHierarchyService.class);
 		
-		Assert.assertEquals(new Integer(2), ahService.getAddressHierarchyEntryCountByLevel(ahService.getAddressHierarchyLevel(1)));
-		Assert.assertEquals(new Integer(3), ahService.getAddressHierarchyEntryCountByLevel(ahService.getAddressHierarchyLevel(2)));
+		Assert.assertEquals(new Integer(3), ahService.getAddressHierarchyEntryCountByLevel(ahService.getAddressHierarchyLevel(1)));
+		Assert.assertEquals(new Integer(4), ahService.getAddressHierarchyEntryCountByLevel(ahService.getAddressHierarchyLevel(2)));
 		Assert.assertEquals(new Integer(2), ahService.getAddressHierarchyEntryCountByLevel(ahService.getAddressHierarchyLevel(3)));
 		Assert.assertEquals(new Integer(3), ahService.getAddressHierarchyEntryCountByLevel(ahService.getAddressHierarchyLevel(4)));
 		Assert.assertEquals(new Integer(8), ahService.getAddressHierarchyEntryCountByLevel(ahService.getAddressHierarchyLevel(5)));
@@ -353,7 +353,7 @@ public class AddressHierarchyServiceTest extends BaseModuleContextSensitiveTest 
 		
 		List<AddressHierarchyEntry> entries = ahService.getAddressHierarchyEntriesAtTopLevel();
 		
-		Assert.assertEquals(2, entries.size());
+		Assert.assertEquals(3, entries.size());
 		Assert.assertTrue(entries.contains(ahService.getAddressHierarchyEntry(1)));
 		Assert.assertTrue(entries.contains(ahService.getAddressHierarchyEntry(16)));
 		
@@ -438,9 +438,10 @@ public class AddressHierarchyServiceTest extends BaseModuleContextSensitiveTest 
         // how about the "null" case?
 		address = new PersonAddress();
 		results = ahService.getPossibleAddressValues(address, "country");
-		Assert.assertEquals(2, results.size());
+		Assert.assertEquals(3, results.size());
 		Assert.assertTrue(results.contains("United States"));
 		Assert.assertTrue(results.contains("China"));
+		Assert.assertTrue(results.contains("កម្ពុជា (Cambodia)"));
 		
 		// how about an unmapped address field?
 		address = new PersonAddress();
@@ -653,8 +654,7 @@ public class AddressHierarchyServiceTest extends BaseModuleContextSensitiveTest 
 		results = ahService.getPossibleFullAddresses(nullTest);
 		Assert.assertEquals(0,results.size());
 	}
-	
-	
+
 	@Test
 	@Verifies(value = "should find possible full addresses that match search string", method = "getPossibleFullAddresses(String)")
 	public void searchAddresses_shouldFindPossibleFullAddressesThatMatchSearchString() throws Exception {
@@ -721,12 +721,14 @@ public class AddressHierarchyServiceTest extends BaseModuleContextSensitiveTest 
         results = ahService.searchAddresses("Accents", null);
         Assert.assertEquals(1,results.size());
         Assert.assertTrue(results.contains("United States|New England|Massachusetts|Plymouth County|Ãccénts"));
+        
+        // test that non-alphanumeric worded addresses are search-able
+        results = ahService.searchAddresses("កម្ពុជា", null);
+        Assert.assertEquals(1,results.size());
+        Assert.assertTrue(results.contains("កម្ពុជា (Cambodia)|ខេត្តឧត្ដរមានជ័យ (Oddar Meanchey)"));
 		
 	}
 	
-
-
-
 	@Test
 	@Verifies(value = "should find possible full addresses that match search string", method = "getPossibleFullAddresses(String)")
 	public void searchAddresses_shouldRestrictSearchToSpecifiedLevel() throws Exception {

--- a/api/src/test/resources/org/openmrs/module/addresshierarchy/include/addressHierarchy-dataset.xml
+++ b/api/src/test/resources/org/openmrs/module/addresshierarchy/include/addressHierarchy-dataset.xml
@@ -34,6 +34,8 @@
     <address_hierarchy_entry address_hierarchy_entry_id="18" name="Ãccénts" level_id="5" parent_id="4" uuid="82e66646-e162-11df-9195-001e378eb67f"/>
     <address_hierarchy_entry address_hierarchy_entry_id="19" name="" user_generated_id="BlankRegion" level_id="7" parent_id="1" uuid="92e66646-e162-11df-9195-001e378eb67f"/>
     <address_hierarchy_entry address_hierarchy_entry_id="20" name="Hawaii" level_id="4" parent_id="19" uuid="93e66646-e162-11df-9195-001e378eb67f"/>
+    <address_hierarchy_entry address_hierarchy_entry_id="21" name="កម្ពុជា (Cambodia)" level_id="1" uuid="e477d1f6-e162-11df-9195-001e378eb67f"/>
+    <address_hierarchy_entry address_hierarchy_entry_id="22" name="ខេត្តឧត្ដរមានជ័យ (Oddar Meanchey)" level_id="2" parent_id="21" uuid="8ebb5bcd-e162-11ef-9295-001e378fb67f"/>
 
 
     <!-- add some references to a person address -->


### PR DESCRIPTION
Ticket: https://issues.openmrs.org/browse/ADDR-125

This PR basically allows for non-alphanumeric words to be searchable, words like កម្ពុជា. 