### PR TITLE
ADDR-141 Revert "TRUNK-6409 Initializer module should not re-run init…

### DIFF
--- a/api/src/main/java/org/openmrs/module/addresshierarchy/config/AddressConfigurationLoader.java
+++ b/api/src/main/java/org/openmrs/module/addresshierarchy/config/AddressConfigurationLoader.java
@@ -23,9 +23,7 @@ import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Responsible for loading the address configuration appropriately
@@ -52,86 +50,6 @@ public class AddressConfigurationLoader {
 	public static String getChecksumsPath() {
 		return Paths.get(OpenmrsUtil.getApplicationDataDirectory(),
 				"configuration_checksums").toString();
-	}
-
-	public static Map<String, String> loadAddressConfiguration(Path configPath, Map<String, String> previousChecksums) {
-		final ConfigDirUtil configUtil = new ConfigDirUtil(configPath.toString(), AddressHierarchyConstants.ADDRESS_HIERARCHY_DOMAIN);
-		final Map<String, String> updatedChecksums = new HashMap<>();
-
-		String xmlConfigFileName = ADDR_CONFIG_FILE_NAME;
-
-		File domainDir = new File(configUtil.domainDirPath);
-		if (!domainDir.exists()) {
-			log.info("Address hierarchy domain folder appears not present, skipping the loading process: " + domainDir.getPath());
-			return updatedChecksums;
-		}
-		File configFile = configUtil.getConfigFile(xmlConfigFileName);
-		if (!configFile.exists()) {
-			log.error("Address hierarchy configuration file appears invalid, skipping the loading process: " + configFile.getPath());
-			return updatedChecksums;
-		}
-
-		String lastChecksum = "";
-		String checksum = "";
-
-		//
-		// Processing the XML configuraton file
-		//
-		AddressConfiguration addressConfiguration = readFromFile(configFile);
-		final String xmlConfigChecksumPath = AddressHierarchyConstants.ADDRESS_HIERARCHY_DOMAIN + "/" + xmlConfigFileName;
-		boolean forceReloadEntries = false;
-
-		lastChecksum = previousChecksums.get(xmlConfigChecksumPath);
-		checksum = configUtil.computeChecksum(xmlConfigFileName);
-
-		if (checksum.equals(lastChecksum)) {
-			log.info("Address hierarchy configuration file is unchanged, skipping it: " + xmlConfigFileName);
-		}
-		else {
-
-			log.info("Address hierarchy configuration file has changed, reloading it: " + xmlConfigFileName);
-
-			if (!isMatchableLevelConfig(addressConfiguration.getAddressComponents()) && !addressConfiguration.mustWipe()) {
-				log.warn("The address hierarchy configuration was not loaded because of a mismatch between the exisiting and provided address hierarchy levels.");
-				return updatedChecksums;
-			}
-
-			if (addressConfiguration.mustWipe()) {
-				log.warn("The exisiting address and address hierarchy configuration is being wiped.");
-				wipeAddressHierarchy();
-			}
-
-			// Address template
-			installAddressTemplate(addressConfiguration.getAddressTemplate());
-
-			// Levels
-			installAddressHierarchyLevels(addressConfiguration.getAddressComponents());
-
-			updatedChecksums.put(xmlConfigChecksumPath, checksum);
-			forceReloadEntries = true;  // if anything upstream is changed, we force reload the address entries from CSV
-		}
-
-		//
-		// Processing the CSV entries file
-		//
-		String csvEntriesFileName = addressConfiguration.getAddressHierarchyFile().getFilename();
-		final String csvEntriesChecksumPath = AddressHierarchyConstants.ADDRESS_HIERARCHY_DOMAIN + "/" + csvEntriesFileName;
-		lastChecksum = previousChecksums.get(csvEntriesChecksumPath);
-		checksum = configUtil.computeChecksum(csvEntriesFileName);
-
-		if (checksum.equals(lastChecksum) && !forceReloadEntries) {
-			log.info("Address hierarchy entries CSV file is unchanged, skipping it: " + csvEntriesFileName);
-		}
-		else {
-			log.info("Address hierarchy entries CSV file has changed, reloading it: " + csvEntriesFileName);
-			installAddressHierarchyEntries(configUtil, addressConfiguration.getAddressHierarchyFile(), forceReloadEntries || addressConfiguration.mustWipe());
-			updatedChecksums.put(csvEntriesChecksumPath, checksum);
-
-			log.info("Entries loaded, re-initializing address cache");
-			getService().initializeFullAddressCache();
-		}
-		getService().initI18nCache();
-		return updatedChecksums;
 	}
 	
 	public static void loadAddressConfiguration(Path configPath, Path checksumsPath) {

--- a/api/src/main/java/org/openmrs/module/addresshierarchy/config/ConfigDirUtil.java
+++ b/api/src/main/java/org/openmrs/module/addresshierarchy/config/ConfigDirUtil.java
@@ -53,10 +53,6 @@ public class ConfigDirUtil {
 		this.checksumDirPath = Paths.get(checksumDirPath, domain).toString();
 	}
 
-	public ConfigDirUtil(String configDirPath, String domain) {
-		this.domainDirPath = Paths.get(configDirPath, domain).toString();
-	}
-
 	public String getDomainDirPath() {
 		return domainDirPath;
 	}


### PR DESCRIPTION
…ialisation on each node"

This reverts commit 1bbf1da5165cb863fa5467e506820c9548eb62e6.

<!--- Add a pull request title above in this format -->
<!--- real example: 'ADDR-128 Add foreignKeyTableName to liquibase constraints' -->
<!--- 'ADDR-JiraIssueNumber JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->


## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://openmrs.atlassian.net/browse/ADDR-141

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
